### PR TITLE
Add Dockerfile for arm32v6 architecture

### DIFF
--- a/Dockerfile.arm32v6
+++ b/Dockerfile.arm32v6
@@ -1,0 +1,21 @@
+FROM arm32v6/alpine:3.6
+
+ADD cloudflare.sh /cloudflare.sh
+ADD crontab /var/spool/cron/crontabs/root
+
+ENV ZONE= \
+    HOST= \
+    EMAIL= \
+    API= \
+    TTL= \
+    PROXY= \
+    DEBUG= \
+    FORCE_CREATE= \
+    RUNONCE=
+
+RUN apk add --update bash jq curl && \
+    rm -rf /var/cache/apk/* && \
+    chmod +x /cloudflare.sh
+
+CMD /cloudflare.sh && \
+    test -z "$RUNONCE" && crond -f


### PR DESCRIPTION
Hi, I was trying to get this running on my raspberry pi and found that there wasn't a build for arm32v6 so I've added a Dockerfile for that.

The change is pretty simple, it just swaps out the base image.

One thing to note is that it doesn't look like docker hub supports automated builds of different architectures so this would need to be manually built on a raspberry pi. I can upload a build from my raspberry pi if you need one.

I'd suggest that this be added to your docker hub repo with a tag similar to 'arm32v6', although that doesn't include the version.