### PR TITLE
Improve IP address queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ Temporary Items
 .apdisk
 
 .idea
+
+# File for setting environment variables for development
+.env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-- Use round-robin approach to obtain for IP from different services
+- Improved reliability of IP address queries
 - Added docker-compose.yml and updated README for easier development
 
 ## [1.4.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Use round-robin approach to obtain for IP from different services
+- Added docker-compose.yml and updated README for easier development
+
 ## [1.4.0]
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.6
 
-ADD cloudflare.sh /cloudflare.sh
+ADD *.sh /
 ADD crontab /var/spool/cron/crontabs/root
 
 ENV ZONE= \

--- a/README.md
+++ b/README.md
@@ -49,3 +49,25 @@ Read the full documentation [here][documentation].
 [documentation]: https://joshuaavalon.github.io/docker-cloudflare/
 [joshuaavalon]: https://hub.docker.com/r/joshuaavalon/cloudflare-ddns/
 [details]: https://joshuaavalon.github.io/docker-cloudflare/faq/
+
+## Developer notes
+
+Create a `.env` file to define your local environment variables (see `sample.env`)
+
+Start the service:
+
+```bash
+docker-compose up
+```
+
+Stop the service:
+
+```bash
+docker-compose down
+```
+
+Rebuild the docker image
+
+```bash
+docker-compose build
+```

--- a/cloudflare.sh
+++ b/cloudflare.sh
@@ -24,26 +24,16 @@ if [[ $TTL != 1 ]] && [[ $TTL -lt 120 || $TTL -gt 2147483647 ]]; then
 fi
 
 echo "Current time: $(date "+%Y-%m-%d %H:%M:%S")"
-if [[ -z $IPV6 ]]; then
-    ip_curl="curl -4s"
-    record_type="A"
-else
-    ip_curl="curl -6s"
-    record_type="AAAA"
-fi
+
+source /query-ip.sh
 
 # Determines the current IP address
-new_ip=$($ip_curl http://ipecho.net/plain)
-
-# IP address service fallbacks
-if [[ -z $new_ip ]]; then
-    new_ip=$($ip_curl http://whatismyip.akamai.com)
-fi
-if [[ -z $new_ip ]]; then
-    new_ip=$($ip_curl http://icanhazip.com/)
-fi
-if [[ -z $new_ip ]]; then
-    new_ip=$($ip_curl https://tnx.nl/ip)
+if [[ -z $IPV6 ]]; then
+    new_ip=$(queryIPAddress 4)
+    record_type="A"
+else
+    new_ip=$(queryIPAddress 6)
+    record_type="AAAA"
 fi
 
 if [[ -z $new_ip ]]; then

--- a/cloudflare.sh
+++ b/cloudflare.sh
@@ -25,9 +25,10 @@ fi
 
 echo "Current time: $(date "+%Y-%m-%d %H:%M:%S")"
 
-source /query-ip.sh
 
 # Determines the current IP address
+source /query-ip.sh
+
 if [[ -z $IPV6 ]]; then
     new_ip=$(queryIPAddress 4)
     record_type="A"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3'
+services:
+  cloudflareddns:
+    build: .
+    environment:
+      - ZONE
+      - HOST
+      - EMAIL
+      - API
+      - TTL
+      - PROXY
+      - DEBUG
+      - FORCE_CREATE
+      - RUNONCE
+      - IPV6

--- a/query-ip.sh
+++ b/query-ip.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+ipv4Services=(
+    "http://ipv4.whatismyip.akamai.com"
+    "http://icanhazip.com/"
+    "https://tnx.nl/ip"
+    "https://v4.ident.me/"
+    "http://ipv4bot.whatismyipaddress.com/"
+    "http://ipecho.net/plain" # This service only supports IPv4
+)
+
+ipv6Services=(
+    "http://ipv6.whatismyip.akamai.com"
+    "http://icanhazip.com/"
+    "https://tnx.nl/ip"
+    "https://v6.ident.me/"
+    "http://ipv6bot.whatismyipaddress.com/"
+)
+
+# Public: Query public IP address for the current system
+#
+# Takes a single argument representing the IP address version desired
+# and attempts to fetch the IP from one of a predefined list of services
+#
+# $1 - IP version: 4 (default) or 6.
+#
+# Examples
+#
+#   queryIPAddress 4
+#
+# Outputs the IPv4 address to stdout
+#
+#   queryIPAddress 6
+#
+# Outputs the IPv6 address to stdout
+queryIPAddress() {
+    local ipVersion="${1:-4}" # Default to version 4
+    local ipServices
+    local ip
+
+    # Select IPv4 or IPv6 services to query
+    [ $ipVersion == 6 ] && ipServices=("${ipv6Services[@]}") || ipServices=("${ipv4Services[@]}")
+
+    local len=${#ipServices[@]} # Total number of available services
+    local retry=$len
+    local i=$((RANDOM % ${#ipServices[@]})) # Randomise initial service to try
+
+    # On each iteration, attempt to obtain IP address.
+    while [ $retry -gt 0 ] && [ -z $ip ]; do
+        echo >&2 "Attempting to obtain IPv${ipVersion} address from ${ipServices[$i]}"
+        ip=$(curl -${ipVersion}s ${ipServices[$i]})
+
+        retry=$(($retry - 1)); # Decrement retry attemps until there are none left
+        i=$((($i + 1) % $len)); # Pick the next service to try from the list
+    done
+
+    [ -z $ip ] && echo >&2 "Failed to obtain IPv${ipVersion} address"
+    echo $ip
+}

--- a/query-ip.sh
+++ b/query-ip.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
+#
+# Provides a function to query the public IP address for the current system
 
-ipv4Services=(
+IPV4_SERVICES=(
     "http://ipv4.whatismyip.akamai.com"
     "http://ipv4bot.whatismyipaddress.com/"
     "http://icanhazip.com/"
@@ -9,7 +11,7 @@ ipv4Services=(
     "https://v4.ident.me/"
 )
 
-ipv6Services=(
+IPV6_SERVICES=(
     "http://ipv6.whatismyip.akamai.com"
     "http://ipv6bot.whatismyipaddress.com/"
     "http://icanhazip.com/"
@@ -17,38 +19,32 @@ ipv6Services=(
     "https://v6.ident.me/"
 )
 
-# Public: Query public IP address for the current system
-#
-# Takes a single argument representing the IP address version desired
-# and attempts to fetch the IP from one of a predefined list of services
-#
-# $1 - IP version: 4 (default) or 6.
-#
-# Examples
-#
-#   queryIPAddress 4
-#
-# Outputs the IPv4 address to stdout
-#
-#   queryIPAddress 6
-#
-# Outputs the IPv6 address to stdout
+
+#######################################
+# Attempt to query IP addresses from the lists of available services for IPv4 and IPv6
+# Globals:
+#   IPV4_SERVICES
+#   IPV6_SERVICES
+# Arguments:
+#   ipVersion: 4 (default) or 6.
+# Returns:
+#   The public IP address corresponding to the specified IP version
+#######################################
 queryIPAddress() {
     local ipVersion="${1:-4}" # Default to version 4
     local ipServices
     local ip
 
     # Select IPv4 or IPv6 services to query
-    [[ $ipVersion == 6 ]] && ipServices=("${ipv6Services[@]}") || ipServices=("${ipv4Services[@]}")
+    [[ $ipVersion == 6 ]] && ipServices=("${IPV6_SERVICES[@]}") || ipServices=("${IPV4_SERVICES[@]}")
 
-    # On each iteration, attempt to obtain IP address.
     for ipService in "${ipServices[@]}"; do
         echo >&2 "Attempting to obtain IPv${ipVersion} address from ${ipService}"
-        ip=$(curl -${ipVersion}s $ipService)
+        ip=$(curl "-${ipVersion}s" "${ipService}")
         [[ -n $ip ]] && break
         echo >&2 "Failed to obtain IPv${ipVersion} address from ${ipService}"
     done
 
-    [[ -z $ip ]] && echo >&2 "Failed to obtain IPv${ipVersion} address from any service."
+    [[ -z $ip ]] && echo >&2 "Failed to obtain IPv${ipVersion} address from any service." && return 1
     echo $ip
 }

--- a/sample.env
+++ b/sample.env
@@ -1,0 +1,9 @@
+ZONE=example.com
+HOST=examle.com
+EMAIL=username@example.com
+API=1234567890abcdef1234567890abcdef12345
+TTL=1
+PROXY=false
+FORCE_CREATE=true
+RUNONCE=1
+IPV6=


### PR DESCRIPTION
Improve code for querying IP addresses.

* Separated the function to query IP addresses into a separate shell script
* This uses a round robin approach to fetch the IP address from the range of services available. Use explicit IPv6 and IPv4 domains where available.
* Makes it easier to add or remove IP address services in the future.
* ipecho.net doesn't support IPv6, so it is now excluded from the IPv6 queries.

Add docker-compose.yml and and update README to improve development experience.